### PR TITLE
@W-23089638 Update UserVerificationProvider override to nullable return type

### DIFF
--- a/sample-messaging/src/main/java/com/salesforce/android/smi/messaging/features/core/UserVerification.kt
+++ b/sample-messaging/src/main/java/com/salesforce/android/smi/messaging/features/core/UserVerification.kt
@@ -6,7 +6,7 @@ import com.salesforce.android.smi.core.UserVerificationToken
 import kotlinx.coroutines.delay
 
 open class UserVerification : UserVerificationProvider {
-    override suspend fun userVerificationChallenge(reason: ChallengeReason): UserVerificationToken =
+    override suspend fun userVerificationChallenge(reason: ChallengeReason): UserVerificationToken? =
         when (reason) {
             ChallengeReason.INITIAL -> authenticate()
             ChallengeReason.RENEW -> renewAuthentication()
@@ -17,7 +17,7 @@ open class UserVerification : UserVerificationProvider {
             }
         }
 
-    open suspend fun authenticate(): UserVerificationToken = delay(1000).let { UserVerificationToken.externalToken("fakeToken") }
+    open suspend fun authenticate(): UserVerificationToken? = delay(1000).let { UserVerificationToken.externalToken("fakeToken") }
 
-    open suspend fun renewAuthentication(): UserVerificationToken = delay(1000).let { UserVerificationToken.externalToken("renewedToken") }
+    open suspend fun renewAuthentication(): UserVerificationToken? = delay(1000).let { UserVerificationToken.externalToken("renewedToken") }
 }


### PR DESCRIPTION
## @W-23089638 - [Android] Update UserVerificationProvider override to nullable return type

  ## Summary
  - Updates `UserVerification` override signatures to return `UserVerificationToken?` (nullable) to align with SDK API change in
  InAppSDK-Android.

  ## Context
  Parent PR: InAppSDK-Android `sarah.young/fix-auth-token-retry-loop`

  The SDK's `UserVerificationProvider.userVerificationChallenge()` now returns nullable to allow signaling that a token cannot
  be provided (e.g., IdP timeout). This PR updates the sample app's implementation to match the new interface signature.

  ## Test plan
  - [x] Compiles successfully against updated SDK
  - [ ] Merge before parent InAppSDK-Android PR updates its submodule ref